### PR TITLE
Add documentation comments to gttrace server (frida/gttrace/server)

### DIFF
--- a/frida/gttrace/server/src/main.rs
+++ b/frida/gttrace/server/src/main.rs
@@ -1,3 +1,8 @@
+//! Entry point for the gttrace server process.
+//!
+//! The server listens on a UNIX datagram socket, decodes incoming JSON
+//! messages from the Frida script, and writes resolved call edges to disk.
+
 mod server;
 mod messages;
 mod mod_lookup;
@@ -7,6 +12,7 @@ use anyhow::{Context, Result};
 use clap::Parser;
 use std::path::PathBuf;
 
+/// Command-line arguments for configuring the gttrace server.
 #[derive(Parser, Debug)]
 #[command(about = "Frida Stalker indirect calls tracer server (Rust port)")]
 struct Args {
@@ -19,6 +25,7 @@ struct Args {
     wl: Option<PathBuf>,
 }
 
+/// Initialize the server and start processing incoming trace messages.
 fn main() -> Result<()> {
     let args = Args::parse();
 

--- a/frida/gttrace/server/src/messages.rs
+++ b/frida/gttrace/server/src/messages.rs
@@ -1,34 +1,51 @@
+//! JSON message parsing helpers for the gttrace server.
+
 use serde::Deserialize;
 
+/// A single control-flow edge captured by Frida Stalker.
 #[derive(Debug, Clone)]
 pub struct CfItem {
+    /// Source address of the indirect call.
     pub from: u64,
+    /// Target address of the indirect call.
     pub target: u64,
+    /// Thread id that emitted the edge.
     pub tid: u32,
 }
 
+/// Module metadata announcement from the Frida script.
 #[derive(Debug, Clone)]
 pub struct ModMessage {
+    /// Module name (e.g., basename of the image).
     pub name: String,
+    /// Module start address.
     pub start: u64,
+    /// Module end address.
     pub end: u64,
+    /// Full path to the module on disk.
     pub path: String,
+    /// Whether this is a removal notification.
     pub remove: bool,
 }
 
+/// Envelope used by Frida's `send()` API.
 #[derive(Debug, Deserialize)]
 pub struct Envelope {
+    /// Message type tag from Frida (typically "send").
     #[serde(rename = "type")]
     pub ty: String,
+    /// Message payload value (shape depends on the message type).
     #[serde(default)]
     pub payload: serde_json::Value,
 }
 
+/// Parse a hexadecimal string (with or without `0x`) into a `u64`.
 fn parse_hex_u64(s: &str) -> Option<u64> {
     let s = s.strip_prefix("0x").unwrap_or(s);
     u64::from_str_radix(s, 16).ok()
 }
 
+/// Parse a control-flow payload into a PID and its list of edges.
 pub fn parse_cf_items(payload: &serde_json::Value) -> Option<(u32, Vec<CfItem>)> {
     let pid = payload.get("pid")?.as_u64()? as u32;
     let items = payload.get("items")?.as_array()?;
@@ -46,6 +63,7 @@ pub fn parse_cf_items(payload: &serde_json::Value) -> Option<(u32, Vec<CfItem>)>
     Some((pid, out))
 }
 
+/// Parse a module announcement payload into a PID and module message.
 pub fn parse_mod_message(payload: &serde_json::Value) -> Option<(u32, ModMessage)> {
     let pid = payload.get("pid")?.as_u64()? as u32;
     let name = payload.get("name")?.as_str()?.to_string();

--- a/frida/gttrace/server/src/mod_lookup.rs
+++ b/frida/gttrace/server/src/mod_lookup.rs
@@ -1,9 +1,15 @@
+//! Module interval lookup helper for resolving addresses to module RVAs.
+
+/// A resolved module name with its relative virtual address (RVA).
 #[derive(Debug, Clone)]
 pub struct ModRva {
+    /// Module name the address belongs to.
     pub module: String,
+    /// Address offset from module base.
     pub rva: u64,
 }
 
+/// Ordered module interval table for fast address-to-module lookups.
 #[derive(Debug, Default, Clone)]
 pub struct ModLookup {
     starts: Vec<u64>,
@@ -12,8 +18,10 @@ pub struct ModLookup {
 }
 
 impl ModLookup {
+    /// Create a new, empty lookup table.
     pub fn new() -> Self { Self::default() }
 
+    /// Insert a non-overlapping module range.
     pub fn add(&mut self, start: u64, end: u64, name: String) -> anyhow::Result<()> {
         anyhow::ensure!(start < end);
 
@@ -32,6 +40,7 @@ impl ModLookup {
         Ok(())
     }
 
+    /// Remove a module range only if the start and end match exactly.
     pub fn rem_exact(&mut self, start: u64, end: u64) -> bool {
         let i = self.starts.partition_point(|&x| x < start);
         if i >= self.starts.len() || self.starts[i] != start || self.ends[i] != end {
@@ -43,6 +52,7 @@ impl ModLookup {
         true
     }
 
+    /// Resolve an absolute address into a module name and RVA.
     pub fn lookup(&self, addr: u64) -> Option<ModRva> {
         let i = self.starts.partition_point(|&x| x <= addr);
         if i == 0 {


### PR DESCRIPTION
### Motivation
- Make the gttrace server codebase easier to understand for contributors by documenting responsibilities, data formats, and runtime behavior.
- Reduce onboarding friction when diagnosing message parsing, module lookup, and output file handling by capturing intent in doc comments.

### Description
- Add module-level docs and a `main` docstring in `frida/gttrace/server/src/main.rs` describing startup, socket binding, and whitelist handling.
- Document the JSON message types and parsing helpers in `frida/gttrace/server/src/messages.rs`, including `Envelope`, `CfItem`, `ModMessage`, and the `parse_*` functions.
- Add explanatory comments to `frida/gttrace/server/src/mod_lookup.rs` for `ModLookup`, `ModRva`, and the semantics of `add`, `rem_exact`, and `lookup`.
- Document output and server behavior in `frida/gttrace/server/src/outman.rs` and `frida/gttrace/server/src/server.rs`, covering `OutputManager` responsibilities, whitelisting, and `serve`/`on_message` lifecycle.

### Testing
- No automated tests were run for these documentation-only changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981ae17d60083219cf89034e99864bb)