### PR TITLE
Add documentation for socktrace agent and server

### DIFF
--- a/frida/socktrace/README.md
+++ b/frida/socktrace/README.md
@@ -1,0 +1,103 @@
+# socktrace
+
+`socktrace` is a Frida-based AF_UNIX socket tracer. It consists of two pieces:
+
+- **Agent**: `frida/socktrace/agent.js` hooks libc socket syscalls inside a target
+  process and emits compact binary frames (GTTR) over a UNIX socket.
+- **Server**: `frida/socktrace/server` receives those frames, decodes them, and
+  writes JSONL events plus per-connection payload files for analysis.
+
+This README focuses on how to run the tracer and how to interpret the output so
+contributors can extend or troubleshoot the pipeline.
+
+## Quick start
+
+### 1) Build the server
+
+From the repo root:
+
+```bash
+cd frida/socktrace/server
+cargo build --release
+```
+
+### 2) Run the server
+
+Pick a UNIX datagram socket path and an output directory:
+
+```bash
+./target/release/socktrace-server /tmp/socktrace.sock /tmp/socktrace-out
+```
+
+The server will create the socket (unlinking it first if it exists) and write
+output into `/tmp/socktrace-out`.
+
+### 3) Load the agent
+
+In your Frida environment, load `frida/socktrace/agent.js` and call
+`rpc.exports.init` with parameters that match your server socket.
+
+Minimal example (JavaScript in your Frida host script):
+
+```js
+await rpc.exports.init(null, {
+  out_socket_path: "/tmp/socktrace.sock",
+});
+```
+
+Optional parameters:
+
+- `max_fds` (int): maximum fd to scan for pre-existing sockets (default 4096).
+- `max_bytes` (int): max payload bytes captured per event (default 4096).
+- `socket_paths` (array): whitelist of UNIX socket paths to trace.
+- `out_sock_type` (string): `"dgram"` (default) or `"stream"`.
+
+## Output format
+
+The server writes two kinds of files into the output directory:
+
+1. **`events.jsonl`**: newline-delimited JSON with metadata for every event.
+2. **`<conn_id>.(in|out).bin`**: raw payload bytes for each connection and
+   direction.
+
+Event objects typically include:
+
+- `type`: one of `open`, `close`, `listen`, `data`, `init`, `ready`, `error`.
+- `ts_ms`: agent-side timestamp (milliseconds).
+- `fd`: file descriptor (when applicable).
+- `path`: UNIX socket path (for listen/open/data).
+- `conn_id`: connection identifier (for open/data/close).
+- `direction`: `in` or `out` (for data).
+- `size`: payload size (for data).
+- `raw`: textual metadata (for init/ready/error).
+
+### Example workflow
+
+```bash
+# Show event stream
+jq -c . /tmp/socktrace-out/events.jsonl | head
+
+# Extract outbound payloads for a connection
+ls /tmp/socktrace-out/*out.bin
+```
+
+## Notes for contributors
+
+- The GTTR frame layout is documented inline in `agent.js` and mirrored in the
+  Rust parser (`server/src/frame.rs`). If you change framing or add new types,
+  update both sides.
+- Connection IDs are sanitized in the agent and used as filenames by the
+  server. Keep the sanitization logic compatible (`safe_filename()` in
+  `server/src/util.rs`).
+- The agent suppresses tracing while it emits frames to avoid recursion. If you
+  add new hooks, be sure to honor the suppression guard and exclude the output
+  socket fd.
+
+## Troubleshooting
+
+- **No output files**: confirm the server is running and the agent is sending to
+  the same `out_socket_path`.
+- **Missing payloads**: verify `max_bytes` is not set too low and that the agent
+  isn't filtering via `socket_paths`.
+- **Errors in events**: look for `error` or `bad_frame` entries in
+  `events.jsonl`.

--- a/frida/socktrace/README.md
+++ b/frida/socktrace/README.md
@@ -18,7 +18,7 @@ From the repo root:
 
 ```bash
 cd frida/socktrace/server
-cargo build --release
+make
 ```
 
 ### 2) Run the server
@@ -33,17 +33,10 @@ The server will create the socket (unlinking it first if it exists) and write
 output into `/tmp/socktrace-out`.
 
 ### 3) Load the agent
+Load the agent with Frida Gadget in script or script-directory mode. 
+In Gadget config provide following paramaters to script:
 
-In your Frida environment, load `frida/socktrace/agent.js` and call
-`rpc.exports.init` with parameters that match your server socket.
-
-Minimal example (JavaScript in your Frida host script):
-
-```js
-await rpc.exports.init(null, {
-  out_socket_path: "/tmp/socktrace.sock",
-});
-```
+- `out_socket_path` (string): socket for traces transfer
 
 Optional parameters:
 

--- a/frida/socktrace/server/src/event.rs
+++ b/frida/socktrace/server/src/event.rs
@@ -1,27 +1,42 @@
+//! JSON-serializable event model written to `events.jsonl`.
+
 use serde::Serialize;
 
+/// Represents a single event derived from a GTTR frame.
+///
+/// Fields are optional to keep the JSONL schema compact; absent fields are
+/// omitted via `skip_serializing_if`.
 #[derive(Serialize)]
 pub struct Event<'a> {
+    /// Event type (e.g., "open", "data", "close").
     #[serde(rename = "type")]
     pub typ: &'a str,
+    /// Timestamp in milliseconds since the agent's epoch (as sent by the agent).
     pub ts_ms: u64,
+    /// File descriptor associated with the event.
     pub fd: i32,
 
+    /// Direction for payload events ("in" or "out").
     #[serde(skip_serializing_if = "Option::is_none")]
     pub direction: Option<&'a str>,
 
+    /// UNIX socket path for listeners or connections.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub path: Option<&'a str>,
 
+    /// Connection identifier emitted by the agent.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub conn_id: Option<&'a str>,
 
+    /// Additional metadata ("how") emitted by the agent.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub how: Option<&'a str>,
 
+    /// Payload size in bytes (if applicable).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub size: Option<usize>,
 
+    /// Free-form raw field used for init/error messages.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub raw: Option<&'a str>,
 }

--- a/frida/socktrace/server/src/main.rs
+++ b/frida/socktrace/server/src/main.rs
@@ -1,3 +1,16 @@
+//! Collects GTTR frames over an AF_UNIX datagram socket and writes structured
+//! JSONL events plus per-connection payload streams.
+//!
+//! This binary pairs with `frida/socktrace/agent.js`:
+//! - The agent emits GTTR frames via a UNIX datagram socket.
+//! - The server decodes frames, normalizes metadata, and persists output in
+//!   `events.jsonl` plus `<conn_id>.(in|out).bin` payload files.
+//! - `conn_id` values are shared with the agent, so sanitization matches
+//!   `safe_filename()` in `util.rs`.
+//!
+//! The output format is intended to be easy to consume with tooling like
+//! `jq`, text editors, or custom scripts.
+
 mod event;
 mod frame;
 mod output;

--- a/frida/socktrace/server/src/util.rs
+++ b/frida/socktrace/server/src/util.rs
@@ -1,5 +1,8 @@
+//! Utility helpers shared by the socktrace server.
+
 use std::time::{SystemTime, UNIX_EPOCH};
 
+/// Converts bytes into a lossy ASCII string (non-printable -> U+FFFD).
 pub fn bytes_to_lossy_ascii(b: &[u8]) -> String {
     // Agent writes mostly ASCII; for non-printable, use replacement char.
     b.iter()
@@ -7,6 +10,7 @@ pub fn bytes_to_lossy_ascii(b: &[u8]) -> String {
         .collect()
 }
 
+/// Sanitizes a string for safe filenames (matches the agent's conn_id format).
 pub fn safe_filename(s: &str) -> String {
     // Mirrors Python regex: [^a-zA-Z0-9_.:@=\-+] => '_'  (see your OutputManager) :contentReference[oaicite:0]{index=0}
     s.chars()
@@ -27,15 +31,18 @@ pub fn safe_filename(s: &str) -> String {
         .collect()
 }
 
+/// Recombines a split u64 timestamp sent as `(lo, hi)` u32s.
 pub fn ts_u64(lo: u32, hi: u32) -> u64 {
     ((hi as u64) << 32) | (lo as u64)
 }
 
+/// Returns the current host timestamp in fractional seconds.
 pub fn host_ts_secs() -> f64 {
     let dur = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default();
     (dur.as_secs() as f64) + (dur.subsec_nanos() as f64) * 1e-9
 }
 
+/// Splits the `conn_id|how` format into `(conn_id, how)` parts.
 pub fn split_conn_how(s: &str) -> (&str, Option<&str>) {
     // JS open: `${connId}|${how}`
     if let Some(pos) = s.find('|') {


### PR DESCRIPTION
### Motivation

- Improve contributor onboarding and maintainability by documenting the Frida agent framing, configuration, and runtime behavior and the server's event/schema/output responsibilities.

### Description

- Add comprehensive inline documentation to `frida/socktrace/agent.js` describing the agent purpose, GTTR framing, RPC `init` params, suppression semantics, symbol resolution and key helper functions like `sendFrame`, `sockaddrUnFromPath`, and `openOutSocket`.
- Document the server binary in `frida/socktrace/server/src/main.rs` with a high-level overview of how it pairs with the agent and the intended outputs (`events.jsonl` and per-connection `<conn_id>.(in|out).bin` files).
- Add doc comments to server-side modules: `event.rs` (event schema fields), `frame.rs` (frame format, type constants, `parse_frame`, and helpers), `output.rs` (purpose of `OutputManager` and its methods), and `util.rs` (helper semantics like `safe_filename`, `ts_u64`, and `bytes_to_lossy_ascii`).
- Changes are documentation-only and do not alter runtime logic or interfaces.

### Testing

- No automated tests were run because these are documentation-only changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981ee540dd48321b0fa6aed8e66a4ac)